### PR TITLE
scripts: lib: llapi: Implement retry handling for API calls

### DIFF
--- a/scripts/lib/llapi.py
+++ b/scripts/lib/llapi.py
@@ -7,6 +7,7 @@ import json
 import os
 import ssl
 import sys
+import time
 import urllib.request
 import urllib.parse
 import urllib.error
@@ -19,6 +20,8 @@ LinuxLinkURL = ll_url_env if ll_url_env else ll_url_default
 LinuxLinkSupportRoute = '/support'
 LinuxLinkSupportURL = LinuxLinkURL + LinuxLinkSupportRoute
 VigilesInfoURL = 'https://www.timesys.com/security/vulnerability-patch-notification/'
+VigilesApiMaxRetries = 5
+VigilesApiRetryTimeout = 5
 
 
 def make_msg(method, resource, data):
@@ -127,32 +130,47 @@ def _do_api_call(request_dict, json_response):
     response = None
 
     url = request_dict['url']
-    err_reason = 'other'
-    err_str = ''
-    try:
-        r = urllib.request.Request(**request_dict)
-        f = urllib.request.urlopen(r, context=context) if context else urllib.request.urlopen(r)
-        if not json_response:
-            return f
-        response = json.loads(f.read().decode('utf-8'), object_pairs_hook=OrderedDict)
-    except urllib.error.HTTPError as e:
-        err_reason = str(e.code)
-        err_str = f.read().decode('utf-8') if f else str(e)
-    except urllib.error.URLError as e:
-        err_reason = 'not-known'
-        err_str = ' '.join([ str(real_e) for real_e in e.args ])
-    except (TypeError, UnicodeDecodeError):
-        err_str = str(e)
-        err_reason = 'content'
-    except Exception as e:
-        err_str = f.read().decode('utf-8') if f else str(e)
-        for real_e in e.args:
-            if isinstance(real_e, TimeoutError):
-                err_reason = 'timeout'
-                break
 
-    if err_str:
-        api_error_message(err_reason, url, err_str)
+    for _ in range(VigilesApiMaxRetries):
+        err_reason = 'other'
+        err_str = ''
+        retry = False
+
+        try:
+            r = urllib.request.Request(**request_dict)
+            f = urllib.request.urlopen(r, context=context) if context else urllib.request.urlopen(r)
+            if not json_response:
+                return f
+            response = json.loads(f.read().decode('utf-8'), object_pairs_hook=OrderedDict)
+        except urllib.error.HTTPError as e:
+            err_reason = str(e.code)
+            err_str = f.read().decode('utf-8') if f else str(e)
+        except urllib.error.URLError as e:
+            err_reason = 'not-known'
+            err_str = ' '.join([ str(real_e) for real_e in e.args ])
+            retry = True
+        except (TypeError, UnicodeDecodeError):
+            err_str = str(e)
+            err_reason = 'content'
+        except Exception as e:
+            err_str = f.read().decode('utf-8') if f else str(e)
+            for real_e in e.args:
+                if isinstance(real_e, TimeoutError):
+                    err_reason = 'timeout'
+                    retry = True
+                    break
+
+        if err_str:
+            api_error_message(err_reason, url, err_str)
+
+        # Error occurred which might be resolved by a retry
+        if retry:
+            print('Retrying in %d seconds' % VigilesApiRetryTimeout, file=sys.stderr)
+            time.sleep(VigilesApiRetryTimeout)
+            continue
+
+        break
+
     return response
 
 


### PR DESCRIPTION
To avoid unnecessary build errors due to short network interruptions,
every API call will be retried up to 5 times before giving up. This is
only done if the error code indicates a temporary network issue as
possible root cause.