### PR TITLE
[vigiles.bbclass] support extra backfill packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,17 @@ VIGILES_EXTRA_PACKAGES = " \
 "
 ```
 
+In order to explicitly include packages which are built by the Bitbake/Yocto
+process but for some reason not present in rootfs manifest (e.g.
+some bootloader or custom firmware may be not picked up through the recursive
+RDEPENDS for the image), VIGILES_EXTRA_BACKFILL may be used.
+
+For example, one may set this in their local.conf:
+
+```
+VIGILES_EXTRA_BACKFILL = "some-firmware-package"
+```
+
 ##### CSV Format
 
 The CSV files consist of an optional header and the following fields:

--- a/classes/vigiles.bbclass
+++ b/classes/vigiles.bbclass
@@ -405,6 +405,7 @@ VIGILES_BACKFILL := "${@' '.join( \
     [ d.getVar('PREFERRED_PROVIDER_%s' % virt, True) or '' \
         for virt in d.getVar('VIGILES_PREFERRED_BACKFILL', True).split() ] \
 )}"
+VIGILES_BACKFILL += "${VIGILES_EXTRA_BACKFILL}"
 
 
 ##

--- a/conf/vigiles.conf
+++ b/conf/vigiles.conf
@@ -47,6 +47,11 @@ VIGILES_WHITELIST ?= "CVE-1234-1234"
 #       <product>, <version>, [<license>]
 VIGILES_EXTRA_PACKAGES ??= ""
 
+# Additional packages which are built by the Bitbake/Yocto process but for some
+# reason not present in rootfs manifest (e.g. some bootloader or custom
+# firmware may be not picked up through the recursive RDEPENDS for the image)
+VIGILES_EXTRA_BACKFILL ?= ""
+
 # This variable can be set to 0 or False to exclude the packages with "CLOSED" Licenses in SBOM
 VIGILES_INCLUDE_CLOSED_LICENSES ?= "1"
 


### PR DESCRIPTION
New variable introduced:
- `VIGILES_EXTRA_BACKFILL`: set this to a list of extra/custom backfill packages to analyze