### PR TITLE
[general] fix kirkstone support

### DIFF
--- a/classes/tsmeta.bbclass
+++ b/classes/tsmeta.bbclass
@@ -309,9 +309,16 @@ def _detect_uboot_version(d):
             _version += _extra
     return _version
 
-def _get_cve_version(d):
+def _get_recipe_pv_with_pfx_sfx(pv, uri_type):
     import oe.recipeutils as oe
+    if hasattr(oe, 'get_recipe_pv_with_pfx_sfx'):
+        func = oe.get_recipe_pv_with_pfx_sfx
+    else:
+        # For yocto kirkstone or older:
+        func = oe.get_recipe_pv_without_srcpv
+    return func(pv, uri_type)
 
+def _get_cve_version(d):
     cve_v = d.getVar('CVE_VERSION')
     if bb.data.inherits_class('kernel', d):
         cve_v = _detect_kernel_version(d)
@@ -328,7 +335,7 @@ def _get_cve_version(d):
     if not cve_v:
         pv = d.getVar('PV')
         uri_type = 'git' if ('git' in pv or 'AUTOINC' in pv) else ''
-        (bpv, pfx, sfx) = oe.get_recipe_pv_with_pfx_sfx(pv, uri_type)
+        (bpv, pfx, sfx) = _get_recipe_pv_with_pfx_sfx(pv, uri_type)
         cve_v = bpv
     return cve_v
 

--- a/classes/vigiles.bbclass
+++ b/classes/vigiles.bbclass
@@ -848,8 +848,6 @@ do_vigiles_kconfig[nostamp] = "1"
 
 
 def _get_uboot_pf(d):
-    from oe import recipeutils as oe
-
     pn = d.getVar('PN')
     boot_pn = d.getVar('VIGILES_UBOOT_PN') or \
         d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or ''
@@ -860,7 +858,7 @@ def _get_uboot_pf(d):
     pv = tsmeta_read_dictname_single(d, 'pn', boot_pn, 'pv')
     if not pv:
         pv = 'unset'
-    (bpv, pfx, sfx) = oe.get_recipe_pv_with_pfx_sfx(pv, 'git')
+    (bpv, pfx, sfx) = _get_recipe_pv_with_pfx_sfx(pv, 'git')
 
     vgls_pf = '-'.join([boot_pn, bpv])
     return vgls_pf


### PR DESCRIPTION
For yocto kirkstone we need to use `oe.get_recipe_pv_without_srcpv()` instead of `oe.get_recipe_pv_with_pfx_sfx()` because `oe.get_recipe_pv_with_pfx_sfx()` doesn't exist for kirkstone.

Let's determine the right function name to call at runtime.

This fixes an issue introduced by commit
[85d1ac7d18af89e3168f83519b0428f6321a8d6e](https://github.com/TimesysGit/meta-timesys/commit/85d1ac7d18af89e3168f83519b0428f6321a8d6e).