### PR TITLE
[vigiles.bbclass] propagate checkcves.py failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,17 @@ To disable initramfs report generation only, set VIGILES_DISABLE_INITRAMFS_REPOR
 VIGILES_DISABLE_INITRAMFS_REPORT = "1"
 ```
 
+### Fail build on CVEs checking issues
+
+Bitbake warnings on checkcves.py failures (e.g. network communication issues
+with Vigiles servers) may go unnoticed. This can be unnaceptable e.g. in cases
+when CVE analysis is triggered by continuous integration. To make sure bitbake
+process fails (exit code is not 0) in such cases, set
+```VIGILES_THROW_ERRORS``` to '1' or 'True' in ```conf/local.conf```
+
+```
+VIGILES_THROW_ERRORS = "1"
+```
 
 Maintenance
 ===========

--- a/classes/tsmeta.bbclass
+++ b/classes/tsmeta.bbclass
@@ -81,6 +81,10 @@ tsmeta_vars_src = "\
     HOMEPAGE                \
 "
 
+def tsmeta_error(d, *args, **kwargs):
+    throw_errors = bb.utils.to_boolean(d.getVar('VIGILES_THROW_ERRORS'), False)
+    func = bb.error if throw_errors else bb.warn
+    func(*args, **kwargs)
 
 def tsmeta_get_type_dir(d, tsm_type):
     key = "tsmeta_" + tsm_type.lower() + "_dir"

--- a/classes/vigiles.bbclass
+++ b/classes/vigiles.bbclass
@@ -1096,11 +1096,11 @@ python do_vigiles_check() {
             os.symlink(os.path.relpath(vigiles_out, os.path.dirname(vigiles_link)), vigiles_link)
 
     except bb.process.CmdError as err:
-        bb.warn("Vigiles: checkcves.py failed: %s" % err)
+        bb.error("Vigiles: checkcves.py failed: %s" % err)
     except bb.process.NotFoundError as err:
-        bb.warn("Vigiles: checkcves.py could not be found: %s" % err)
+        bb.error("Vigiles: checkcves.py could not be found: %s" % err)
     except Exception as err:
-        bb.warn("Vigiles: run_checkcves failed: %s" % err)
+        bb.error("Vigiles: run_checkcves failed: %s" % err)
 }
 
 

--- a/classes/vigiles.bbclass
+++ b/classes/vigiles.bbclass
@@ -1096,11 +1096,11 @@ python do_vigiles_check() {
             os.symlink(os.path.relpath(vigiles_out, os.path.dirname(vigiles_link)), vigiles_link)
 
     except bb.process.CmdError as err:
-        bb.error("Vigiles: checkcves.py failed: %s" % err)
+        tsmeta_error(d, "Vigiles: checkcves.py failed: %s" % err)
     except bb.process.NotFoundError as err:
-        bb.error("Vigiles: checkcves.py could not be found: %s" % err)
+        tsmeta_error(d, "Vigiles: checkcves.py could not be found: %s" % err)
     except Exception as err:
-        bb.error("Vigiles: run_checkcves failed: %s" % err)
+        tsmeta_error(d, "Vigiles: run_checkcves failed: %s" % err)
 }
 
 

--- a/conf/vigiles.conf
+++ b/conf/vigiles.conf
@@ -58,3 +58,8 @@ SPDX_CUSTOM_ANNOTATION_VARS ??= ""
 # If Generating initramfs SBOM is disabled it will disable initramfs report generation by default
 VIGILES_DISABLE_INITRAMFS_SBOM ??= ""
 VIGILES_DISABLE_INITRAMFS_REPORT ??= "${@d.getVar('VIGILES_DISABLE_INITRAMFS_SBOM')}"
+
+# This variable can be set to 1 or True to make sure bitbake process fails
+# (exit code is not 0) on failures while checking CVEs (e.g. on network
+# communication issues with Vigiles servers).
+VIGILES_THROW_ERRORS ?= "0"


### PR DESCRIPTION
Bitbake warnings on `checkcves.py` failures (e.g. network communication issues with Vigiles servers) may go unnoticed. This can be unnaceptable e.g. in cases when CVE analysis is triggered by continuous integration. Hence we need to make sure bitbake process fails (exit code is not 0) in such cases.