### PR TITLE
[vigiles.bbclass] Fix deprecated datetime.utcnow from python3.12

### DIFF
--- a/classes/vigiles.bbclass
+++ b/classes/vigiles.bbclass
@@ -226,14 +226,14 @@ def get_package_checksum(d):
 
 
 def get_package_annotations(d):
-    from datetime import datetime
+    from datetime import datetime, UTC
 
     def add_annotation(comment):
         tool_name = d.getVar("VIGILES_SPDX_TOOL_NAME")
         tool_version = d.getVar("VIGILES_TOOL_VERSION")
 
         annotation = {}
-        annotation["annotationDate"] = datetime.utcnow().isoformat()
+        annotation["annotationDate"] = datetime.now(UTC).isoformat()
         annotation["annotationType"] = "OTHER"
         annotation["comment"] = comment
         
@@ -555,7 +555,7 @@ def _get_packages(d, pn_list):
     return dict_out
 
 def vigiles_image_collect(d):
-    from datetime import datetime
+    from datetime import datetime, UTC
 
     def get_dep_pns(pn, deps, tsmeta_dir):
         dep_pns = set()
@@ -715,7 +715,7 @@ def vigiles_image_collect(d):
     _name = d.getVar('VIGILES_MANIFEST_NAME')[:int(d.getVar('VIGILES_MANIFEST_NAME_MAX_LENGTH'))]
 
     dict_out = dict(
-            date             = datetime.utcnow().isoformat(),
+            date             = datetime.now(UTC).isoformat(),
             distro           = sys_dict["distro"]["codename"],
             distro_version   = sys_dict["distro"]["version"],
             image            = sys_dict["image"]["basename"],

--- a/scripts/checkcves.py
+++ b/scripts/checkcves.py
@@ -222,8 +222,8 @@ def parse_cvss_counts(counts, severity):
 
 
 def print_report_header(result, f_out=None):
-  from datetime import datetime
-  report_time = result.get('date', datetime.utcnow().isoformat())
+  from datetime import datetime, UTC
+  report_time = result.get('date', datetime.now(UTC).isoformat())
 
   print('-- Vigiles Vulnerability Scanner --\n\n'
           '\t%s\n\n' % INFO_PAGE, file=f_out)


### PR DESCRIPTION
With Python version 3.12 and above, the `datetime.utcnow()` is deprecated and there is a warning for it when building as below

`WARNING: cross-localedef-native-2.39+git-r0 do_vigiles_pkg: /home/xxx/timesys/build/../meta-timesys/classes/vigiles.bbclass:236: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). annotation["annotationDate"] = datetime.utcnow().isoformat()`