### PR TITLE
Check if the patch is actually a file.

### DIFF
--- a/classes/vigiles.bbclass
+++ b/classes/vigiles.bbclass
@@ -28,6 +28,7 @@ def _get_patched(src_patches):
     # This is originally from cve-check.bbclass; input/output adapted for our needs.
 
     import re
+    from pathlib import Path
 
     patched_dict = dict()
 
@@ -46,6 +47,12 @@ def _get_patched(src_patches):
         if fname_match:
             cve = fname_match.group(1).upper()
             found_cves.append(cve)
+
+        patch_path = Path(patch_file)
+
+        if not patch_path.is_file():
+          bb.warn(f"Skip patch CVE check - is not a file: {patch_file}")
+          continue
 
         with open(patch_file, "r", encoding="utf-8") as f:
             try:


### PR DESCRIPTION
We came across an issue with Vigiles when a URL like this is in SRC_URIs:

git://github.com/pkg/diff;name=diff;destsuffix=build/vendor/src/github.com/pkg/diff;branch=main;protocol=https

The script falsely detects the folder git2/github.com.pkg.diff as a patch file. 
This change checks if the assumed patch is actually a file before trying to read it.


